### PR TITLE
Fix macros on hosts that have no existing macros, fixes #11

### DIFF
--- a/library/centreon_host.py
+++ b/library/centreon_host.py
@@ -319,6 +319,8 @@ def main():
     #### Macros
     if macros:
         m_state, m_list = host.getmacro()
+        if m_list is None:
+            m_list = {}
         for k in macros:
             if k.get('name').find("$_HOST") == 0:
                 current_macro = m_list.get(k.get('name'))


### PR DESCRIPTION
The API returns None, we need an empty dict.