### PR TITLE
Add meta/main.yml file

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  author: Guillaume Watteeux
+  description: An Ansible module to configure Centreon
+  license: GPLv3
+  min_ansible_version: 2.4.0
+  platforms:
+  - name: Ubuntu
+    versions:
+    - all


### PR DESCRIPTION
When following the README and installing this module with ansible-galaxy, the following warning is produced and ansible-centreon is not installed:
```
[WARNING]: - ansible-modules-centreon was NOT installed successfully: this role does not
appear to have a meta/main.yml file.
```

This MR adds the required `meta/main.yml` file.